### PR TITLE
Prevent Liquid from incorrectly parsing code block

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -29,7 +29,7 @@ Additional information includes:
 ### Citing this Work
 
 If you would like to cite this overview in your (academic) work, we recommend to cite the exact release that the cited information refers to, e.g.,
-
+<!--  {% raw %} --> 
 ```
 @misc{idd100,
   author = {{Intrusion Detection Datasets} contributors},
@@ -39,6 +39,7 @@ If you would like to cite this overview in your (academic) work, we recommend to
   note = {[Online; accessed DD-MMM-YYYY]},
 }
 ```
+<!-- {% endraw %} -->
 
 ### Acknowledgments
 

--- a/docs/new_entry_template.md
+++ b/docs/new_entry_template.md
@@ -52,6 +52,10 @@ What kind of data was collected and how it is present in the dataset, including 
 ### Data Examples
 Snippet from the dataset, ideally one for each data type.
 Note that multi-word annotations (like `json lines`) will not render properly on GitHub Pages.
+Wrapping these snippets with `raw`/`endraw` is not strictly required, but prevents Liquid from parsing anything it shouldn't.
+
+<!--  {% raw %} -->
 ```
 data example
 ```
+<!--  {% endraw %} -->


### PR DESCRIPTION
Discovered a new downside of our approach:
GitHub pages will interpret certain text segments as [Liquid templates](https://liquidjs.com/index.html), which results in an error (aka failed build) because some of our stuff of course doesn't match the syntax Liquid would expect.

Simple solution here is to wrap such segments with 
```
<!--  {% raw %} --> 
// stuff here
<!--  {% endraw %} --> 
```
Putting this into a comment (`<!-- ... -->`) isn't required, but we don't want this text to appear on our actual webpage.
I also added this to the template for new dataset entries.